### PR TITLE
erlperf: update to support OTP 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ Cluster-wide monitoring will reflect changes accordingly.
 
 ## Changelog
 
+Version 1.1.5:
+- support for OTP 25 (peer replacing slave)
+
 Version 1.1.4:
 - fixed an issue with pg already started
 - moved profiling to spawned process

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,6 +1,6 @@
  ** this is the overview.doc file for the application 'erlperf' **
 
-   @version 1.1.3
+   @version 1.1.5
    @author Maxim Fedorov, <maximfca@gmail.com>
    @title erlperf: Erlang Performance & Benchmarking Suite.
 

--- a/src/ep_cluster_history.erl
+++ b/src/ep_cluster_history.erl
@@ -70,7 +70,7 @@ get(From, To) ->
 %% Suppress dialyzer warning for OTP compatibility: erlperf runs on OTP20
 %%  that does not support pg, and has pg2 instead.
 -dialyzer({no_missing_calls, init/1}).
--compile({nowarn_deprecated, [{pg2, create, 1}, {pg2, join, 2}]}).
+-compile({nowarn_deprecated_function, [{pg2, create, 1}, {pg2, join, 2}]}).
 -compile({nowarn_removed, [{pg2, create, 1}, {pg2, join, 2}]}).
 init([]) ->
     try

--- a/src/ep_monitor_proxy.erl
+++ b/src/ep_monitor_proxy.erl
@@ -49,7 +49,7 @@ start_link() ->
 %% Suppress dialyzer warning for OTP compatibility: erlperf runs on OTP20
 %%  that does not support pg, and has pg2 instead.
 -dialyzer({no_missing_calls, init/1}).
--compile({nowarn_deprecated, [{pg2, create, 1}, {pg2, join, 2}]}).
+-compile({nowarn_deprecated_function, [{pg2, create, 1}, {pg2, join, 2}]}).
 -compile({nowarn_removed, [{pg2, create, 1}, {pg2, get_members, 1}]}).
 -spec init([]) -> {ok, state()}.
 init([]) ->

--- a/src/erlperf.app.src
+++ b/src/erlperf.app.src
@@ -1,6 +1,6 @@
 {application, erlperf,
  [{description, "Erlang Performance & Benchmarking Suite"},
-  {vsn, "1.1.4"},
+  {vsn, "1.1.5"},
   {registered, [
     erlperf_sup, ep_monitor_sup, ep_job_sup, ep_monitor,
     ep_history, ep_file_log, ep_cluster_history,
@@ -10,7 +10,8 @@
   {mod, {erlperf_app, []}},
   {applications,
    [kernel,
-    stdlib
+    stdlib,
+    argparse
    ]},
   {env,[]},
   {modules, []},


### PR DESCRIPTION
In OTP 25, `slave` module is replaced with `peer`.

Fixes #8 as well.