### PR TITLE
[erlperf] usability fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+- minor bugfixes (friendlier error reporting)
+
 ## 2.0
 - incompatible change: `erlperf` requires runner arity to be defined explicitly.
   Code example: `erlperf:run(#{runner => {timer, sleep, []}, init_runner => "1."})`,

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ When there are multiple jobs, multiple columns are printed.
 Command-line benchmarking does not save results anywhere. It is designed to provide a quick answer to the question
 "is that piece of code faster".
 
-## Minimal overhead mode
-Since 2.0, `erlperf` includes "low overhead" mode. It cannot be used for continuous benchmarking. In this mode
+## Timed (low overhead) mode
+Since 2.0, `erlperf` includes timed mode. It cannot be used for continuous benchmarking. In this mode
 runner code is executed specified amount of times in a tight loop:
 
 ```bash
@@ -130,7 +130,7 @@ runner code is executed specified amount of times in a tight loop:
 ```
 
 This mode effectively runs following code: `loop(0) -> ok; loop(Count) -> rand:uniform(), loop(Count - 1).`
-Continuous mode adds 1-2 ns to each iteration.
+Timed mode reduced benchmarking overhead (compared to continuous mode) by 1-2 ns per iteration.
 
 # Benchmarking existing application
 `erlperf` can be used to measure performance of your application running in production, or code that is stored
@@ -319,7 +319,7 @@ two times faster than applying a function, and 20 times faster than repeatedly c
 the same invocation method to get a relevant result.
 
 Absolute benchmarking overhead may be significant for very fast functions taking just a few nanoseconds.
-Use "low overhead mode" for such occasions.
+Use timed mode for such occasions.
 
 ## Experimental: recording call chain
 This experimental feature allows capturing a sequence of calls as a list of
@@ -404,7 +404,7 @@ Number of `run/0` calls per second is reported as throughput. Before 2.0, `erlpe
 used `atomics` to maintain a counter shared between all runner processes, introducing
 unnecessary BIF call overhead. 
 
-Low-overhead mode tightens it even further, turning runner into this function:
+Timed (low-overhead) mode tightens it even further, turning runner into this function:
 ```erlang
 runner(0) ->
     ok;

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,6 +1,6 @@
  ** this is the overview.doc file for the application 'erlperf' **
 
-   @version 2.0.0
+   @version 2.0.1
    @author Maxim Fedorov, <maximfca@gmail.com>
    @title erlperf: Erlang Performance & Benchmarking Suite.
 
@@ -123,8 +123,8 @@
    Command-line benchmarking does not save results anywhere. It is designed to provide a quick answer to the question
    "is that piece of code faster".
 
-   === Minimal overhead mode ===
-   Since 2.0, `erlperf' includes "low overhead" mode. It cannot be used for continuous benchmarking. In this mode
+   === Timed (low overhead) mode ===
+   Since 2.0, `erlperf' includes timed mode. It cannot be used for continuous benchmarking. In this mode
    runner code is executed specified amount of times in a tight loop:
 
    ```
@@ -135,7 +135,8 @@
    '''
 
    This mode effectively runs following code: `loop(0) -> ok; loop(Count) -> rand:uniform(), loop(Count - 1).'
-   Continuous mode adds 1-2 ns to each iteration.
+   Timed mode reduced benchmarking overhead (compared to continuous mode) by 1-2 ns per iteration.
+
 
    == Benchmarking existing application ==
    `erlperf' can be used to measure performance of your application running in production, or code that is stored
@@ -324,7 +325,7 @@
    the same invocation method to get a relevant result.
 
    Absolute benchmarking overhead may be significant for very fast functions taking just a few nanoseconds.
-   Use "low overhead mode" for such occasions.
+   Use timed mode for such occasions.
 
    === Experimental: recording call chain ===
    This experimental feature allows capturing a sequence of calls as a list of
@@ -409,7 +410,7 @@
    used `atomics' to maintain a counter shared between all runner processes, introducing
    unnecessary BIF call overhead.
 
-   Low-overhead mode tightens it even further, turning runner into this function:
+   Timed (low-overhead) mode tightens it even further, turning runner into this function:
    ```
    runner(0) ->
        ok;

--- a/src/erlperf.app.src
+++ b/src/erlperf.app.src
@@ -1,6 +1,6 @@
 {application, erlperf,
  [{description, "Erlang Performance & Benchmarking Suite"},
-  {vsn, "2.0.0"},
+  {vsn, "2.0.1"},
   {registered, [
     erlperf_sup, erlperf_job_sup, erlperf_monitor,
    erlperf_history, erlperf_file_log, erlperf_cluster_monitor

--- a/src/erlperf.erl
+++ b/src/erlperf.erl
@@ -32,7 +32,7 @@
     % ignored when running concurrency test
     concurrency => pos_integer(),
     %% sampling interval: default is 1000 milliseconds (to measure QPS)
-    %% 'undefined' duration is used as a flag for low-overhead benchmarking
+    %% 'undefined' duration is used as a flag for timed benchmarking
     sample_duration => pos_integer() | undefined,
     %% warmup samples: first 'warmup' cycles are ignored (defaults to 0)
     warmup => non_neg_integer(),
@@ -187,7 +187,7 @@ start(Code, Concurrency) ->
     Job.
 
 %% @doc
-%% Low-overhead benchmarking, runs the code Count times and returns
+%% Timed benchmarking, runs the code Count times and returns
 %%  time in microseconds it took to execute the code.
 -spec time(code(), Count :: non_neg_integer()) -> TimeUs :: non_neg_integer().
 time(Code, Count) ->

--- a/src/erlperf_file_log.erl
+++ b/src/erlperf_file_log.erl
@@ -127,7 +127,9 @@ format_number(Num) ->
 
 %% @doc Formats time duration, from nanoseconds to seconds
 %%  Example: 88 -> 88 ns, 88000 -> 88 us, 10000000 -> 10 ms
--spec format_duration(non_neg_integer()) -> string().
+-spec format_duration(non_neg_integer() | infinity) -> string().
+format_duration(infinity) ->
+    "inf";
 format_duration(Num) when Num > 100000000000 ->
     integer_to_list(round(Num / 1000000000)) ++ " s";
 format_duration(Num) when Num > 100000000 ->


### PR DESCRIPTION
Report 'inf' instead of crashing on zero throughput.
Print user-readable compile errors.
Correctly name "timed" mode "timed" (not just low-overhead).