### PR TITLE
WIP: Use escript to write erlperf benchmarks

### DIFF
--- a/src/erlperf_cli.erl
+++ b/src/erlperf_cli.erl
@@ -7,7 +7,8 @@
 
 %% Public API: escript
 -export([
-    main/1
+    main/1,
+    main_impl/3
 ]).
 
 %% @doc Simple command-line benchmarking interface.
@@ -316,6 +317,10 @@ format_code(Code) when is_tuple(Code) ->
     lists:flatten(io_lib:format("~tp", [Code]));
 format_code(Code) when is_tuple(hd(Code)) ->
     lists:flatten(io_lib:format("[~tp, ...]", [hd(Code)]));
+format_code(Code) when is_function(Code) ->
+    {module, _Mod} = erlang:fun_info(Code, module),
+    {name, Name} = erlang:fun_info(Code, name),
+    lists:flatten(io_lib:format("~tp:~tp", [escript, Name]));
 format_code(Code) ->
     Code.
 


### PR DESCRIPTION
erlperf as it stands does not allow, or at least makes it unnecessarily hard, to write benchmarks as escripts, kinda like benchee does it. The CLI produces the nice output but cannot be invoked from an escript directly, on the other hand the erlperf:run and others do not produce nice output, and only give you a single number as a result.

What I would like to achieve is to be able to write a script like:

```erlang
#!/usr/bin/env escript
%%! +pc unicode -pa /path/to/erlperf/ebin
-mode(compile).

main(_) ->
    erlperf_cli:main_impl(#{}, #{}, [
        #{runner => fun() -> rand:uniform(10) end},
        #{runner => {timer, sleep, [5]}}
    ]),
    halt(0).
```

which, when executed, will produce a familiar erlperf output:

```
$ ../erlperf-script.escript
Code                             ||        QPS       Time     Rel
escript:'-main/1-fun-0-'          1   23958 Ki      41 ns    100%
{timer,sleep,[5]}                 1        166    6024 us      0%

```

This is a very early attempt to achieve the desired result with minimal changes to erlperf codebase to assess the feasibility. Looks promising, if you ask me =)