### PR TITLE
erlperf: fixes and updates to 2.1.0

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -11,16 +11,17 @@ jobs:
   linux:
     name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        otp_version: ['23', '24', '25']
+        otp_version: [23, 24, 25]
         os: [ubuntu-latest]
+
+    container:
+      image: erlang:${{ matrix.otp_version }}
+
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp_version}}
-          rebar3-version: '3.17.0'
       - name: Run tests
         run: rebar3 ct
       - name: Generate documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.0
+- fixed -w (--warmup) argument missing from command line
+- synchronised worker startup when adding concurrency
+- concurrent worker shutdown when reducing concurrency
+- elevated job & benchmark process priority to avoid result skew
+- implemented scheduling problem detection (e.g. lock contention),
+  added a busy loop method workaround
+
 ## 2.0.2
 - added convenience command line options: init_all, done_all, init_runner_all
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,17 @@ halved:
     rand:uniform().          1    2771 Ki      72 ns
 ```
 
+## Benchmarking under lock contention
+ERTS cannot guarantee precise timing when there is severe lock contention happening,
+and scheduler utilisation is 100%. This often happens with ETS:
+```bash
+    $ ./erlperf -c 50 'ets:insert(ac_tab, {1, 2}).'
+```
+Running 50 concurrent processes trying to overwrite the very same key of an ETS
+table leads to lock contention on a shared resource (ETS table/bucket lock).
+
+
+
 ## Concurrency test (squeeze)
 Sometimes it's necessary to measure code running multiple concurrent
 processes, and find out when it saturates the node. It can be used to

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.2.0",
-[{<<"argparse">>,{pkg,<<"argparse">>,<<"1.2.3">>},0}]}.
+[{<<"argparse">>,{pkg,<<"argparse">>,<<"1.2.4">>},0}]}.
 [
 {pkg_hash,[
- {<<"argparse">>, <<"20578A5D86250D7FB1BF6D116054BF707C247395E740BC8FC1384CC49DFB06F7">>}]},
+ {<<"argparse">>, <<"A31E7C5D9F8814AFCD9B42C1B98C21DA6F851F93F2C8C00C107F6201668A0A7D">>}]},
 {pkg_hash_ext,[
- {<<"argparse">>, <<"BFE94654811112FB86880C47B3600313D8D2281A1CCE4DADA2B09E5C3C9988D3">>}]}
+ {<<"argparse">>, <<"AC6FDB7183EA20ADEB7EB66E34B21F2E8C4C6925913EE0C0765D339D97009FFE">>}]}
 ].

--- a/src/erlperf.app.src
+++ b/src/erlperf.app.src
@@ -1,6 +1,6 @@
 {application, erlperf,
  [{description, "Erlang Performance & Benchmarking Suite"},
-  {vsn, "2.0.2"},
+  {vsn, "2.1.0"},
   {registered, [
     erlperf_sup, erlperf_job_sup, erlperf_monitor,
    erlperf_history, erlperf_file_log, erlperf_cluster_monitor

--- a/src/erlperf_app.erl
+++ b/src/erlperf_app.erl
@@ -1,4 +1,4 @@
-%%% @copyright (C) 2019-2022, Maxim Fedorov
+%%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
 %%% Continuous benchmarking application behaviour.
 %%% @end

--- a/src/erlperf_cli.erl
+++ b/src/erlperf_cli.erl
@@ -1,4 +1,4 @@
-%%% @copyright (C) 2019-2022, Maxim Fedorov
+%%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
 %%% Command line interface adapter.
 %%% @end
@@ -37,7 +37,7 @@ main(Args) ->
                     RunOpts0;
                 {ok, Str} ->
                     [erlang:error({loop, Option}) || Option <-
-                        [concurrency, sample_duration, samples, waarmup, cv], is_map_key(Option, RunOpts0)],
+                        [concurrency, sample_duration, samples, warmup, cv], is_map_key(Option, RunOpts0)],
                     RunOpts0#{loop => parse_loop(Str)}
                 end,
 

--- a/src/erlperf_cluster_monitor.erl
+++ b/src/erlperf_cluster_monitor.erl
@@ -1,4 +1,4 @@
-%%% @copyright (C) 2019-2022, Maxim Fedorov
+%%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
 %%% Logs monitoring events for the entire cluster, to file or device.
 %%%  Requires erlperf_history service running, fails otherwise.

--- a/src/erlperf_file_log.erl
+++ b/src/erlperf_file_log.erl
@@ -1,4 +1,4 @@
-%%% @copyright (C) 2019-2022, Maxim Fedorov
+%%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
 %%%   Writes monitoring events to I/O device.
 %%% @end

--- a/src/erlperf_history.erl
+++ b/src/erlperf_history.erl
@@ -1,4 +1,4 @@
-%%% @copyright (C) 2019-2022, Maxim Fedorov
+%%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
 %%% Collects, accumulates &amp; filters cluster-wide monitoring events.
 %%% Essentially a simple in-memory database for quick cluster overview.

--- a/src/erlperf_job_sup.erl
+++ b/src/erlperf_job_sup.erl
@@ -1,4 +1,4 @@
-%%% @copyright (C) 2019-2022, Maxim Fedorov
+%%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% Supervises statically started jobs.
 %%% @end
 -module(erlperf_job_sup).

--- a/src/erlperf_monitor.erl
+++ b/src/erlperf_monitor.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2019-2022, Maxim Fedorov
+%%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
 %%%   System monitor: scheduler, RAM, and benchmarks throughput
 %%%  samples.

--- a/src/erlperf_sup.erl
+++ b/src/erlperf_sup.erl
@@ -1,4 +1,4 @@
-%%% @copyright (C) 2019-2022, Maxim Fedorov
+%%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
 %%% Top-level supervisor. Always starts process group scope
 %%%  for `erlperf'. Depending on the configuration starts

--- a/test/erlperf_file_log_SUITE.erl
+++ b/test/erlperf_file_log_SUITE.erl
@@ -1,4 +1,4 @@
-%%% @copyright (c) 2019-2022 Maxim Fedorov
+%%% @copyright (c) 2019-2023 Maxim Fedorov
 %%% @doc
 %%%     Tests erlperf_file_log
 %%% @end

--- a/test/erlperf_history_SUITE.erl
+++ b/test/erlperf_history_SUITE.erl
@@ -1,4 +1,4 @@
-%%% @copyright (c) 2019-2022 Maxim Fedorov
+%%% @copyright (c) 2019-2023 Maxim Fedorov
 %%% @doc
 %%% Tests combination of erlperf_monitor, erlperf_cluster_monitor,
 %%%  erlperf_history and erlperf_job. This is an integration test

--- a/test/erlperf_job_SUITE.erl
+++ b/test/erlperf_job_SUITE.erl
@@ -1,4 +1,4 @@
-%%% @copyright (c) 2019-2022 Maxim Fedorov
+%%% @copyright (c) 2019-2023 Maxim Fedorov
 %%% @doc
 %%% Tests all combinations of code maps accepted by erlperf_job
 %%% @end
@@ -47,10 +47,12 @@ overhead(Config) when is_list(Config) ->
     %% special case: code with no init/state/MFA/fun/... can be optimised
     %%  to a simple "for-loop" and get executed with the lease overhead
     {ok, Job} = erlperf_job:start_link(#{runner => "rand:uniform(1000)."}),
+    high = erlperf_job:set_priority(Job, max),
     Sampler = erlperf_job:handle(Job),
     TimeUs = erlperf_job:measure(Job, SampleCount),
     %% measure the same thing now with continuous benchmark
     ok = erlperf_job:set_concurrency(Job, 1),
+    {priority, max} = erlang:process_info(Job, priority),
     %% fetch a sample
     Start = erlperf_job:sample(Sampler),
     timer:sleep(1000),

--- a/test/erlperf_monitor_SUITE.erl
+++ b/test/erlperf_monitor_SUITE.erl
@@ -1,6 +1,6 @@
 %%%-------------------------------------------------------------------
 %%% @author Maxim Fedorov <maximfca@gmail.com>
-%%% @copyright (c) 2019-2022 Maxim Fedorov
+%%% @copyright (c) 2019-2023 Maxim Fedorov
 %%% @doc
 %%%     Tests monitor
 %%% @end


### PR DESCRIPTION
Major change is to detect lock contention and apply busy wait in the primary process. It does not reduce total throughput too much, because CPU is not actually busy, so spinning on it does not introduce too much of a problem.

Changes:
 * bumped argparse to 1.2.4
 * fixed -w (--warmup) argument missing from command line
 * synchronised worker startup when adding concurrency
 * concurrent worker shutdown when reducing concurrency
 * elevated job & benchmark process priority to avoid result skew
 * implemented scheduling problem detection (e.g. lock contention), added a busy loop method workaround