### PR TITLE
erlperf: switch to ex_doc

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -24,8 +24,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run tests
         run: rebar3 ct
-      - name: Generate documentation
+      - name: Documentation
         run: rebar3 edoc
+      - name: ExDoc Documentation
+        run: if [ $(rebar3 version | awk '{print $5}') -gt 23 ]; then rebar3 ex_doc; fi;
       - shell: bash
         name: Dialyzer
         run: rebar3 dialyzer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.1
+- improved documentation, switched from edoc to ex_doc
+- added convenience functions and defaults to monitor, file_log, cluster_monitor and history
+- refined types for better Dialyzer analysis
+
 ## 2.1.0
 - fixed -w (--warmup) argument missing from command line
 - synchronised worker startup when adding concurrency

--- a/rebar.config
+++ b/rebar.config
@@ -33,12 +33,16 @@
     {doc, #{provider => ex_doc}}
 ]}.
 
+{project_plugins, [rebar3_ex_doc]}.
+
 {ex_doc, [
     {extras, [
+        {"README.md", #{title => "Overview"}},
         {"CHANGELOG.md", #{title => "Changelog"}},
-        {"LICENSE.md", #{title => "License"}},
-        {"README.md", #{title => "Overview"}}
+        {"LICENSE.md", #{title => "License"}}
     ]},
     {main, "README.md"},
-    {source_url, "https://github.com/max-au/erlperf"}
+    {source_url, "https://github.com/max-au/erlperf"},
+    {output, <<"_build/ex_doc">>},
+    {source_ref, <<"master">>}
 ]}.

--- a/src/erlperf.app.src
+++ b/src/erlperf.app.src
@@ -1,6 +1,6 @@
 {application, erlperf,
  [{description, "Erlang Performance & Benchmarking Suite"},
-  {vsn, "2.1.0"},
+  {vsn, "2.1.1"},
   {registered, [
     erlperf_sup, erlperf_job_sup, erlperf_monitor,
    erlperf_history, erlperf_file_log, erlperf_cluster_monitor

--- a/src/erlperf_app.erl
+++ b/src/erlperf_app.erl
@@ -1,7 +1,6 @@
 %%% @copyright (C) 2019-2023, Maxim Fedorov
-%%% @doc
+%%% @private
 %%% Continuous benchmarking application behaviour.
-%%% @end
 -module(erlperf_app).
 -author("maximfca@gmail.com").
 

--- a/src/erlperf_cli.erl
+++ b/src/erlperf_cli.erl
@@ -1,7 +1,6 @@
 %%% @copyright (C) 2019-2023, Maxim Fedorov
-%%% @doc
+%%% @private
 %%% Command line interface adapter.
-%%% @end
 -module(erlperf_cli).
 -author("maximfca@gmail.com").
 
@@ -243,7 +242,7 @@ main_impl(RunOpts, SqueezeOpts, Codes) ->
             true ->
                 {ok, P} = pg:start_link(erlperf),
                 {ok, Mon} = erlperf_monitor:start_link(),
-                {ok, Log} = erlperf_file_log:start_link(group_leader()),
+                {ok, Log} = erlperf_file_log:start_link(),
                 {P, Mon, Log};
             false ->
                 {undefined, undefined, undefined}

--- a/src/erlperf_cluster_monitor.erl
+++ b/src/erlperf_cluster_monitor.erl
@@ -1,10 +1,30 @@
 %%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
 %%% Logs monitoring events for the entire cluster, to file or device.
-%%%  Requires erlperf_history service running, fails otherwise.
-%%% Uses completely different to erlperf_monitor approach; instead of waiting
+%%%  Requires {@link erlperf_history} service running, fails otherwise.
+%%% Uses completely different to {@link erlperf_monitor} approach; instead of waiting
 %%%  for new samples to come, cluster monitor just outputs existing
 %%%  samples periodically.
+%%%
+%%% Example primary node:
+%%% ```
+%%%     rebar3 shell --sname primary
+%%%     (primary@ubuntu22)1> erlperf_history:start_link().
+%%%     {ok,<0.211.0>}
+%%%     (primary@ubuntu22)2> erlperf_cluster_monitor:start_link().
+%%%     {ok,<0.216.0>}
+%%% '''
+%%%
+%%% Example benchmarking node:
+%%% ```
+%%%     rebar3 shell --sname bench1
+%%%     (bench1@ubuntu22)1> net_kernel:connect_node('primary@ubuntu22').
+%%%     true
+%%%     (bench1@ubuntu22)2> erlperf:run(rand, uniform, []).
+%%% '''
+%%%
+%%% As soon as the new benchmarking jon on the node `bench' is started, it is
+%%% reported in the cluster monitoring output.
 %%% @end
 -module(erlperf_cluster_monitor).
 -author("maximfca@gmail.com").
@@ -13,7 +33,8 @@
 
 %% API
 -export([
-    start_link/2
+    start_link/0,
+    start_link/3
 ]).
 
 %% gen_server callbacks
@@ -27,56 +48,87 @@
 %% Handler: just like gen_event handler.
 %% If you do need gen_event handler, make a fun of it.
 -type handler() :: {module(), atom(), term()} | file:filename_all() | {fd, io:device()} | io:device().
+%% Specifies monitoring output device.
+%%
+%% It could be an output {@link io:device()} (such as
+%% {@link erlang:group_leader/0}, `user' or `standard_error'), a file name, or a
+%% `{Module, Function, UserState}' tuple. In the latter case, instead of printing, cluster monitor
+%% calls the specified function, which must have arity of 2, accepting filtered
+%% {@link erlperf_monitor:monitor_sample()} as the first argument, and `Userstate' as the second,
+%% returning next `UserState'.
+
+
+%% Take a sample every second
+-define(DEFAULT_INTERVAL, 1000).
+
+-define(KNOWN_FIELDS, [time, sched_util, dcpu, dio, processes, ports, ets, memory_total,
+    memory_processes, memory_ets, jobs]).
+
+%% @equiv start_link(erlang:group_leader(), 1000, undefined)
+-spec start_link() -> {ok, Pid :: pid()} | {error, Reason :: term()}.
+start_link() ->
+    start_link(erlang:group_leader(), ?DEFAULT_INTERVAL, undefined).
 
 %% @doc
-%% Starts cluster-wide monitor with the specified handler, and links it to the caller.
-%% Use 'record_info(fields, monitor_sample)' to fetch all fields.
--spec start_link(handler(), [atom()]) -> {ok, Pid :: pid()} | {error, Reason :: term()}.
-start_link(Handler, Fields) ->
-    gen_server:start_link(?MODULE, [Handler, Fields], []).
+%% Starts cluster-wide monitor process, and links it to the caller.
+%%
+%% Intended to be used in a supervisor `ChildSpec', making the process a part of the supervision tree.
+%%
+%% `IntervalMs' specifies time, in milliseconds, between output handler invocations.
+%%
+%% Fields specifies the list of field names to report, and the order in which columns are printed.
+%% see {@link erlperf_monitor:monitor_sample()} for options. Passing `undefined' prints all columns
+%% known by this version of `erlperf'.
+%% @end
+-spec start_link(Handler :: handler(), IntervalMs :: pos_integer(), Fields :: [atom()] | undefined) ->
+    {ok, Pid :: pid()} | {error, Reason :: term()}.
+start_link(Handler, Interval, Fields) ->
+    gen_server:start_link(?MODULE, [Handler, Interval, Fields], []).
 
 %%%===================================================================
 %%% gen_server callbacks
-
-%% Take a sample every second
--define(SAMPLING_RATE, 1000).
 
 %% System monitor state
 -record(state, {
     %% next tick
     next :: integer(),
+    interval :: pos_integer(),
     handler :: handler(),
-    fields :: [atom()],
+    fields :: [atom()] | undefined,
     %% previously printed header, elements are node() | field name | job PID
     %% if the new header is different from the previous one, it gets printed
     header = [] :: [atom() | {jobs, [pid()]} | {node, node()}]
 }).
 
-%% gen_server init
-init([Handler, Fields]) ->
+%% @private
+init([Handler, Interval, Fields0]) ->
     %% precise (abs) timer
-    Next = erlang:monotonic_time(millisecond) + ?SAMPLING_RATE,
-    {ok, handle_tick(#state{next = Next, handler = make_handler(Handler), fields = Fields})}.
+    Fields = if Fields0 =:= undefined -> ?KNOWN_FIELDS; true -> Fields0 end,
+    Next = erlang:monotonic_time(millisecond) + Interval,
+    {ok, handle_tick(#state{next = Next, interval = Interval, handler = make_handler(Handler), fields = Fields})}.
 
+%% @private
 handle_call(_Request, _From, _State) ->
     erlang:error(notsup).
 
+%% @private
 handle_cast(_Request, _State) ->
     erlang:error(notsup).
 
+%% @private
 handle_info({timeout, _, tick}, State) ->
     {noreply, handle_tick(State)}.
 
 %%%===================================================================
 %%% Internal functions
 
-handle_tick(#state{next = Next, fields = Fields, handler = Handler, header = Header} = State) ->
-    Next1 = Next + ?SAMPLING_RATE,
+handle_tick(#state{next = Next, interval = Interval, fields = Fields, handler = Handler, header = Header} = State) ->
+    Next1 = Next + Interval,
     %% if we supply negative timer, we crash - and restart with no messages in the queue
     %% this could happen if handler is too slow
     erlang:start_timer(Next1, self(), tick, [{abs, true}]),
     %% fetch all updates from cluster history
-    Samples = erlperf_history:get(Next - ?SAMPLING_RATE + erlang:time_offset(millisecond)),
+    Samples = erlperf_history:get(Next - Interval + erlang:time_offset(millisecond)),
     %% now invoke the handler
     {NewHandler, NewHeader} = run_handler(Handler, Fields, Header, lists:keysort(1, Samples)),
     State#state{next = Next1, handler = NewHandler, header = NewHeader}.
@@ -84,6 +136,8 @@ handle_tick(#state{next = Next, fields = Fields, handler = Handler, header = Hea
 make_handler({_M, _F, _A} = MFA) ->
     MFA;
 make_handler(IoDevice) when is_pid(IoDevice); is_atom(IoDevice) ->
+    {fd, IoDevice};
+make_handler({fd, IoDevice}) when is_pid(IoDevice); is_atom(IoDevice) ->
     {fd, IoDevice};
 make_handler(Filename) when is_list(Filename); is_binary(Filename) ->
     {ok, Fd} = file:open(Filename, [raw, append]),
@@ -118,7 +172,7 @@ run_handler({fd, IoDevice}, Fields, Header, Samples) ->
     NewHeader =/= Header andalso
         begin
             FmtHdr = iolist_to_binary(lists:join(" ", [header(S) || S <- NewHeader])),
-            ok = file:write(IoDevice, FmtHdr)
+            ok = file:write(IoDevice, <<FmtHdr/binary, "\n">>)
         end,
     %% print the actual line
     Data = lists:join(" ", Filtered) ++ "\n",

--- a/src/erlperf_file_log.erl
+++ b/src/erlperf_file_log.erl
@@ -1,6 +1,15 @@
 %%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
-%%%   Writes monitoring events to I/O device.
+%%% Prints monitoring reports produced by {@link erlperf_monitor} to file
+%%% or an output device.
+%%%
+%%% When the server starts up, it joins `{erlperf, Node}' process group
+%%% in the `erlperf' scope. If {@link erlperf_monitor} is also running in
+%%% the same node, reports are printed to the specified device or file.
+%%%
+%%% See {@link erlperf_monitor} for description of the monitoring report.
+%%%
+%%% `erlperf' leverages this service for verbose output during benchmarking.
 %%% @end
 -module(erlperf_file_log).
 -author("maximfca@gmail.com").
@@ -9,6 +18,7 @@
 
 %% API
 -export([
+    start_link/0,
     start_link/1,
     %% leaky API...
     format_number/1,
@@ -24,13 +34,16 @@
     handle_info/2
 ]).
 
-%%--------------------------------------------------------------------
+%% @equiv start_link(erlang:group_leader())
+-spec start_link() -> {ok, Pid :: pid()} | {error, Reason :: term()}.
+start_link() ->
+    start_link(erlang:group_leader()).
+
 %% @doc
-%% Starts the server
--spec(start_link(Filename :: string() | file:io_device()) -> {ok, Pid :: pid()} | {error, Reason :: term()}).
+%% Starts the file log process.
+-spec start_link(Filename :: string() | file:io_device()) -> {ok, Pid :: pid()} | {error, Reason :: term()}.
 start_link(Filename) ->
     gen_server:start_link(?MODULE, [Filename], []).
-
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -52,19 +65,22 @@ start_link(Filename) ->
     jobs = [] :: [erlperf_monitor:job_sample()]
 }).
 
-%% gen_server init
+%% @private
 init([Target]) ->
     % subscribe to monitor events
     ok = pg:join(erlperf, {erlperf_monitor, node()}, self()),
     WriteTo = if is_list(Target) -> {ok, LogFile} = file:open(Target, [raw, append]), LogFile; true -> Target end,
     {ok, #state{log_file = WriteTo}}.
 
+%% @private
 handle_call(_Request, _From, _State) ->
     erlang:error(notsup).
 
+%% @private
 handle_cast(_Request, _State) ->
     erlang:error(notsup).
 
+%% @private
 handle_info(#{jobs := Jobs, time := Time, sched_util := SchedUtil, dcpu := DCPU, dio := DIO, processes := Processes,
     ports := Ports, ets := Ets, memory_total := MemoryTotal, memory_processes := MemoryProcesses,
     memory_binary := MemoryBinary, memory_ets := MemoryEts}, #state{log_file = File} = State) ->
@@ -100,6 +116,7 @@ write_header(File, Jobs) ->
     ok = file:write(File, Header),
     Format.
 
+%% @private
 %% @doc Formats size (bytes) rounded to 3 digits.
 %%  Unlike @see format_number, used 1024 as a base,
 %%  so 200 * 1024 is 200 Kb.
@@ -113,6 +130,7 @@ format_size(Num) when Num > 1024 * 100 ->
 format_size(Num) ->
     integer_to_list(Num).
 
+%% @private
 %% @doc Formats number rounded to 3 digits.
 %%  Example: 88 -> 88, 880000 -> 880 Ki, 100501 -> 101 Ki
 -spec format_number(non_neg_integer()) -> string().
@@ -125,6 +143,7 @@ format_number(Num) when Num > 100000 ->
 format_number(Num) ->
     integer_to_list(Num).
 
+%% @private
 %% @doc Formats time duration, from nanoseconds to seconds
 %%  Example: 88 -> 88 ns, 88000 -> 88 us, 10000000 -> 10 ms
 -spec format_duration(non_neg_integer() | infinity) -> string().

--- a/src/erlperf_job_sup.erl
+++ b/src/erlperf_job_sup.erl
@@ -1,6 +1,6 @@
 %%% @copyright (C) 2019-2023, Maxim Fedorov
+%%% @private
 %%% Supervises statically started jobs.
-%%% @end
 -module(erlperf_job_sup).
 -author("maximfca@gmail.com").
 

--- a/src/erlperf_monitor.erl
+++ b/src/erlperf_monitor.erl
@@ -1,8 +1,37 @@
 %%%-------------------------------------------------------------------
 %%% @copyright (C) 2019-2023, Maxim Fedorov
 %%% @doc
-%%%   System monitor: scheduler, RAM, and benchmarks throughput
-%%%  samples.
+%%% System monitor: reports scheduler, RAM, and benchmarks.
+%%%
+%%% Monitor is started by default when `erlperf' starts
+%%% as an application. Monitor is not started for ad-hoc
+%%% benchmarking (e.g. command-line, unless verbose logging
+%%% is requested).
+%%%
+%%% When started, the monitor provides periodic reports
+%%% about Erlang VM state, and registered jobs performance.
+%%% The reports are sent to all processes that joined
+%%% `{erlperf_monitor, Node}' or `cluster_monitor' process
+%%% group in `erlperf' scope.
+%%%
+%%% Reports can be received by any process, even the shell. Run
+%%% the following example in `rebar3 shell' of `erlperf':
+%%% ```
+%%% (erlperf@ubuntu22)1> ok = pg:join(erlperf, cluster_monitor, self()).
+%%% ok
+%%% (erlperf@ubuntu22)2> erlperf:run(rand, uniform, []).
+%%% 14976933
+%%% (erlperf@ubuntu22)4> flush().
+%%% Shell got {erlperf@ubuntu22,#{dcpu => 0.0,dio => 6.42619095979426e-4,
+%%%                         ets => 44,jobs => [],memory_binary => 928408,
+%%%                         memory_ets => 978056,
+%%%                         memory_processes => 8603392,
+%%%                         memory_total => 34952096,ports => 5,
+%%%                         processes => 95,
+%%%                         sched_util => 0.013187335960637163,
+%%% '''
+%%%
+%%%
 %%% @end
 -module(erlperf_monitor).
 -author("maximfca@gmail.com").
@@ -12,7 +41,9 @@
 %% API
 -export([
     start/0,
+    start/1,
     start_link/0,
+    start_link/1,
     register/3,
     unregister/1
 ]).
@@ -30,7 +61,7 @@
 
 -define(DEFAULT_TICK_INTERVAL_MS, 1000).
 
-%% Monitoring sampling structure
+
 -type monitor_sample() :: #{
     time => integer(),
     sched_util => float(),
@@ -45,32 +76,93 @@
     memory_ets => non_neg_integer(),
     jobs => [{Job :: pid(), Cycles :: non_neg_integer()}]
 }.
+%% Monitoring report
+%%
+%% <ul>
+%%   <li>`time': timestamp when the report is generates, wall clock, milliseconds</li>
+%%   <li>`sched_util': normal scheduler utilisation, percentage. See {@link scheduler:utilization/1}</li>
+%%   <li>`dcpu': dirty CPU scheduler utilisation, percentage.</li>
+%%   <li>`dio': dirty IO scheduler utilisation, percentage</li>
+%%   <li>`processes': number of processes in the VM.</li>
+%%   <li>`ports': number of ports in the VM.</li>
+%%   <li>`ets': number of ETS tables created in the VM.</li>
+%%   <li>`memory_total': total VM memory usage, see {@link erlang:memory/1}.</li>
+%%   <li>`memory_processes': processes memory usage, see {@link erlang:system_info/1}.</li>
+%%   <li>`memory_binary': binary memory usage.</li>
+%%   <li>`memory_ets': ETS memory usage.</li>
+%%   <li>`jobs': a map of job process identifier to the iterations surplus
+%%    since last sample. If the sampling interval is default 1 second, the
+%%    value of the map is "requests/queries per second" (RPS/QPS).</li>
+%% </ul>
 
--export_type([monitor_sample/0]).
+-type start_options() :: #{
+    interval => pos_integer()
+}.
+%% Monitor startup options
+%%
+%% <ul>
+%%   <li>`interval': monitoring interval, 1000 ms by default</li>
+%% </ul>
 
-%%--------------------------------------------------------------------
-%% @doc
-%% Starts the server (unlinked, not supervised, used only for
-%%  isolated BEAM runs)
--spec(start() -> {ok, Pid :: pid()} | {error, Reason :: term()}).
+-export_type([monitor_sample/0, start_options/0]).
+
+%% @equiv start(#{interval => 1000})
+-spec start() -> {ok, Pid :: pid()} | {error, Reason :: term()}.
 start() ->
-    gen_server:start({local, ?MODULE}, ?MODULE, [], []).
+    start(#{interval => ?DEFAULT_TICK_INTERVAL_MS}).
 
 %% @doc
-%% Starts the server
+%% Starts the monitor.
+%%
+%% `Options' are used to change the monitor behaviour.
+%% <ul>
+%%    <li>`interval': time, in milliseconds, to wait between sample collection</li>
+%% </ul>
+-spec start(Options :: start_options()) -> {ok, Pid :: pid()} | {error, Reason :: term()}.
+start(Options) ->
+    gen_server:start({local, ?MODULE}, ?MODULE, Options, []).
+
+%% @equiv start_link(#{interval => 1000})
 -spec(start_link() -> {ok, Pid :: pid()} | {error, Reason :: term()}).
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    start_link(#{interval => ?DEFAULT_TICK_INTERVAL_MS}).
 
 %% @doc
-%% Registers job to monitor (ignoring failures, as monitor may not be
-%%  running).
+%% Starts the monitor and links it to the current process. See {@link start/1}
+%% for options description.
+start_link(Options) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Options, []).
+
+%% @doc
+%% Registers an {@link erlperf_job} to monitor.
+%%
+%% Running monitor queries every registered job, adding
+%% the number of iterations performed by all workers of
+%% that job to the report.
+%% This API is intended to be used by {@link erlperf_job}
+%% to enable VM monitoring while benchmarking.
+%%
+%% `Job' specifies job process identifier, it is only
+%% used to detect when job is stopped, to stop reporting
+%% counters for that job.
+%%
+%% `Handle' is the sampling handle, see {@link erlperf_job:handle/1}.
+%%
+%% `Initial' value should be provided when an existing job
+%% is registered, to avoid reporting accumulated counter value
+%% in the first report for that job.
+%%
+%% Always return `ok', even when monitor is not running.
 -spec register(pid(), term(), non_neg_integer()) -> ok.
 register(Job, Handle, Initial) ->
     gen_server:cast(?MODULE, {register, Job, Handle, Initial}).
 
 %% @doc
-%% Removes the job from monitoring (e.g. job has no workers running)
+%% Removes the job from monitoring.
+%%
+%% Stops reporting this job performance.
+%%
+%% `Job' is the process identifier of the job.
 -spec unregister(pid()) -> ok.
 unregister(Job) ->
     gen_server:cast(?MODULE, {unregister, Job}).
@@ -81,7 +173,7 @@ unregister(Job) ->
 %% System monitor state
 -record(state, {
     % bi-map of job processes to counters
-    jobs :: [{pid(), reference(), Handle :: erlperf_job:handle(), Prev :: integer()}]    ,
+    jobs :: [{pid(), reference(), Handle :: erlperf_job:handle(), Prev :: integer()}],
     % scheduler data saved from last call
     sched_data :: [{pos_integer(), integer(), integer()}],
     % number of normal schedulers
@@ -93,17 +185,16 @@ unregister(Job) ->
     next_tick :: integer()
 }).
 
-init([]) ->
-    %% subscribe to jobs starting up
+%% @private
+init(#{interval := Tick}) ->
     %% TODO: figure out if there is a way to find jobs after restart.
     %% ask a supervisor? but not all jobs are supervised...
-    Jobs = [],
     %% Jobs = [{Pid, erlperf_job:handle(Pid), 0} ||
     %%        {_, Pid, _, _} <- try supervisor:which_children(erlperf_job_sup) catch exit:{noproc, _} -> [] end],
     %% [monitor(process, Pid) || {Pid, _, _} <- Jobs],
+    Jobs = [],
     %% enable scheduler utilisation calculation
     erlang:system_flag(scheduler_wall_time, true),
-    Tick = ?DEFAULT_TICK_INTERVAL_MS,
     Next = erlang:monotonic_time(millisecond) + Tick,
     erlang:start_timer(Next, self(), tick, [{abs, true}]),
     {ok, #state{
@@ -115,9 +206,11 @@ init([]) ->
         dcpu = erlang:system_info(dirty_cpu_schedulers)}
     }.
 
+%% @private
 handle_call(_Request, _From, _State) ->
     erlang:error(notsup).
 
+%% @private
 handle_cast({register, Job, Handle, Initial}, #state{jobs = Jobs} = State) ->
     MRef = monitor(process, Job),
     {noreply, State#state{jobs = [{Job, MRef, Handle, Initial} | Jobs]}};
@@ -130,9 +223,11 @@ handle_cast({unregister, Job}, #state{jobs = Jobs} = State) ->
             {noreply, State}
     end.
 
+%% @private
 handle_info({'DOWN', _MRef, process, Pid, _Reason}, #state{jobs = Jobs} = State) ->
     {noreply, State#state{jobs = lists:keydelete(Pid, 1, Jobs)}};
 
+%% @private
 handle_info({timeout, _, tick}, State) ->
     {noreply, handle_tick(State)}.
 

--- a/src/erlperf_sup.erl
+++ b/src/erlperf_sup.erl
@@ -1,9 +1,8 @@
 %%% @copyright (C) 2019-2023, Maxim Fedorov
-%%% @doc
+%%% @private
 %%% Top-level supervisor. Always starts process group scope
 %%%  for `erlperf'. Depending on the configuration starts
 %%%  a number of jobs or a cluster-wide monitoring solution.
-%%% @end
 -module(erlperf_sup).
 -author("maximfca@gmail.com").
 

--- a/test/erlperf_history_SUITE.erl
+++ b/test/erlperf_history_SUITE.erl
@@ -51,11 +51,11 @@ monitor_cluster(Config) ->
     AllFields = [time, sched_util, dcpu, dio, processes, ports, ets, memory_total, memory_processes, memory_ets, jobs],
 
     %% start cluster monitor
-    {ok, ClusterHandlePid} = erlperf_cluster_monitor:start_link({?MODULE, handle_update, [Control]}, AllFields),
+    {ok, ClusterHandlePid} = erlperf_cluster_monitor:start_link({?MODULE, handle_update, [Control]}, 1000, AllFields),
     %% start another cluster monitor (now printing to console)
-    {ok, ClusterMonPid} = erlperf_cluster_monitor:start_link(erlang:group_leader(), AllFields),
+    {ok, ClusterMonPid} = erlperf_cluster_monitor:start_link(),
     %% start 3rd cluster monitor printing to a file
-    {ok, ClusterFilePid} = erlperf_cluster_monitor:start_link(LogFile, AllFields),
+    {ok, ClusterFilePid} = erlperf_cluster_monitor:start_link(LogFile, 1000, AllFields),
 
     %% start a benchmark on the different node, and monitor progress
     %% link the process to kill it if timetrap fires


### PR DESCRIPTION
While at it, improve documentation about rarely used modules, add missing specs, refine existing specs, and add convenience functions.