### PR TITLE
Implement optional runner label

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -43,6 +43,7 @@ erlperf --init_runner '2.' 'run(1) -> ok.' 'run(2) -> ok.' --init_runner '1.'
 | --init            | Job initialisation code, see accepted callable formats below              |
 | --init_runner     | Worker initialisation code                                                |
 | --done            | Job cleanup code                                                          |
+| --label           | Runner label                                                              |
 |                   |                                                                           |
 | --init_all        | Default init code for all runners that do not have a specific code        |
 | --init_runner_all | Default init_runner code                                                  |

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A benchmark may define following functions:
 * **init** (optional): executed once when the job starts
 * **done** (optional): executed once when the job is about to stop
 * **init_runner** (optional): executed on every worker process startup
+* **label** (optional): string that overrides the code value in reports
 
 See `erlperf_job` for the detailed reference and ways to define a function (**callable**).
 
@@ -271,7 +272,7 @@ This is the default report form when less than 10 samples were collected.
 Use `-r basic` to force basic reports with 10 and more samples.
 
 Basic report contains following columns:
- * **Code**: Erlang code supplied to the benchmark
+ * **Code**: Erlang code or label supplied to the benchmark
  * **||**: how many concurrent processes were running. In the timed mode, it is always 1. In the concurrency
    estimation mode, the number that achieved the highest total throughput (QPS)
  * **QPS**: average number of runner code *iterations* (throughput). Measure per single *sample_duration*

--- a/src/erlperf_job.erl
+++ b/src/erlperf_job.erl
@@ -184,7 +184,8 @@
     runner := callable(),
     init => callable(),
     init_runner => callable(),
-    done => callable()
+    done => callable(),
+    label => iodata()
 }.
 %% Code map contains definitions for:
 %%
@@ -207,6 +208,8 @@
 %%   <li>`done/0,1' - called when the job terminates, to clean up any resources
 %%       that are not destroyed automatically. done/0 accepts the return of init/0.
 %%       Call is made in the context of the job controller</li>
+%%   <li>`label' - runner label displayed in reports.
+%%       By default, the runner code is converted to a string</li>
 %% </ul>
 
 %% Internal (opaque) type, please do not use

--- a/test/erlperf_cli_SUITE.erl
+++ b/test/erlperf_cli_SUITE.erl
@@ -16,7 +16,8 @@
     full_report/1, basic_timed_report/1, full_timed_report/1,
     recorded/1,
     squeeze/0, squeeze/1, step/1,
-    init_all/0, init_all/1
+    init_all/0, init_all/1,
+    label/1
 ]).
 
 %%--------------------------------------------------------------------
@@ -27,7 +28,8 @@ suite() ->
 
 all() ->
     [simple, concurrent, verbose, zero, compare, squeeze, step, usage, init, double,
-        triple, pg, mfa, full_report, basic_timed_report, full_timed_report, recorded, init_all].
+        triple, pg, mfa, full_report, basic_timed_report, full_timed_report, recorded, init_all,
+            label].
 
 %%--------------------------------------------------------------------
 %% helper functions
@@ -342,3 +344,10 @@ init_all(Config) when is_list(Config) ->
     ?assert(C3 > 5 andalso C3 < 11, {qps, C3}), %% 10 ms delay
     ?assert(R > R2), %% 5 ms delay is less than 2 ms
     ?assert(R2 > R3). %% 5 ms delay is more than 10 ms
+
+% erlperf 'foo.' --label bar
+label(Config) when is_list(Config) ->
+    Out = capture_io(
+        fun () -> erlperf_cli:main(["foo.", "--label", "bar"]) end),
+    [{Label, _, _, _}] = parse_out(Out),
+    ?assertEqual("bar", Label).


### PR DESCRIPTION
This PR implements a runner label option to give more control of the report `Code` column output.

_Example:_

```erlang
1> io:format(erlperf_cli:format(erlperf:benchmark([#{runner => "foo.", label => "bar"}], #{report => full}, undefined), #{format => full})).
Code     ||   Samples       Avg   StdDev    Median      P99  Iteration
bar       1         3    129 Mi    0.86%    128 Mi   130 Mi       7 ns
```

_CLI example:_

```shell
$ /erlperf 'foo.' --label "bar" 
Code         ||        QPS       Time
bar           1     136 Mi       7 ns
```

If the label is undefined, the actual behavior is preserved.

_Example:_

```erlang
1> io:format(erlperf_cli:format(erlperf:benchmark([#{runner => "foo."}], #{report => full}, undefined), #{format => full})).
Code     ||   Samples       Avg   StdDev    Median      P99  Iteration
foo.      1         3    130 Mi    0.14%    130 Mi   130 Mi       7 ns
```

_CLI example:_

```shell
$ /erlperf 'foo.'
Code         ||        QPS       Time
foo.          1     131 Mi       7 ns
```

## Motivation

I'm using functions in benchmarks of one of my libs, and the output is not readable: https://github.com/williamthome/euneus?tab=readme-ov-file#results